### PR TITLE
ユーザー作成・ログインAPI修正

### DIFF
--- a/reagent-order-kotlin-backend/reagent_order/src/main/kotlin/kkito/reagent_order/app_user/controller/AppUserController.kt
+++ b/reagent-order-kotlin-backend/reagent_order/src/main/kotlin/kkito/reagent_order/app_user/controller/AppUserController.kt
@@ -3,6 +3,7 @@ package kkito.reagent_order.app_user.controller
 import kkito.reagent_order.app_user.entity.AppUserEntity
 import kkito.reagent_order.app_user.service.AppUserService
 import kkito.reagent_order.app_user.value.*
+import kkito.reagent_order.login.value.LoginResponse
 import kkito.reagent_order.util.ControllerUtil
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller
@@ -19,7 +20,7 @@ class AppUserController(
     private val appUserService: AppUserService,
 ) : ControllerUtil() {
     @PostMapping("/app_user/create")
-    fun createAppUser(@RequestBody createAppUserRequest: CreateAppUserRequest): ResponseEntity<AppUserResponse> {
+    fun createAppUser(@RequestBody createAppUserRequest: CreateAppUserRequest): ResponseEntity<LoginResponse> {
         val appUser = AppUserEntity(
             AppUserId(UUID.randomUUID()),
             AppUserName(createAppUserRequest.appUserName),

--- a/reagent-order-kotlin-backend/reagent_order/src/main/kotlin/kkito/reagent_order/app_user/service/AppUserService.kt
+++ b/reagent-order-kotlin-backend/reagent_order/src/main/kotlin/kkito/reagent_order/app_user/service/AppUserService.kt
@@ -1,36 +1,36 @@
 package kkito.reagent_order.app_user.service
 
 import kkito.reagent_order.app_user.entity.AppUserEntity
-import kkito.reagent_order.app_user.value.AppUserResponse
 import kkito.reagent_order.app_user.repository.AppUserRepository
 import kkito.reagent_order.app_user.service.spec.AppUserCreateSpec
 import kkito.reagent_order.app_user.service.spec.AppUserDeleteSpec
 import kkito.reagent_order.app_user.service.spec.AppUserUpdateSpec
-import kkito.reagent_order.app_user.value.AppUserDto
-import kkito.reagent_order.app_user.value.AppUserId
+import kkito.reagent_order.app_user.value.*
 import kkito.reagent_order.error.ErrorCode
 import kkito.reagent_order.error.NotFoundException
+import kkito.reagent_order.login.service.LoginService
+import kkito.reagent_order.login.value.LoginResponse
 import org.springframework.stereotype.Service
 
 @Service
 open class AppUserService(
     private val appUserCreateSpec: AppUserCreateSpec,
+    private val loginService: LoginService,
     private val appUserUpdateSpec: AppUserUpdateSpec,
     private val appUserDeleteSpec: AppUserDeleteSpec,
     private val appUserRepository: AppUserRepository
 ) {
-    fun createAppUser(appUserEntity: AppUserEntity): AppUserResponse {
+    fun createAppUser(appUserEntity: AppUserEntity): LoginResponse {
         // アプリユーザが重複していないかの確認
         appUserCreateSpec.check(appUserEntity)
 
         // 永続化
         appUserRepository.createAppUser(appUserEntity)
-        return AppUserResponse(
-            appUserEntity.id.toString(),
-            appUserEntity.appUserName.toString(),
-            appUserEntity.email.toString(),
-            appUserEntity.createdAt,
-            appUserEntity.role
+
+        // 作成したユーザーでログイン処理
+        return loginService.getAppUser(
+            Email(appUserEntity.email.value),
+            Password(appUserEntity.password.value)
         )
     }
 

--- a/reagent-order-kotlin-backend/reagent_order/src/main/kotlin/kkito/reagent_order/login/value/LoginResponse.kt
+++ b/reagent-order-kotlin-backend/reagent_order/src/main/kotlin/kkito/reagent_order/login/value/LoginResponse.kt
@@ -1,9 +1,8 @@
 package kkito.reagent_order.login.value
 
-import kkito.reagent_order.app_user.entity.AppUserEntity
 import kkito.reagent_order.app_user.value.AppUserResponse
 
 data class LoginResponse(
     val appUserEntity: AppUserResponse,
-    val loginId: String,
+    val token: String,
 )

--- a/reagent-order-kotlin-backend/reagent_order/src/test/kotlin/kkito/reagent_order/app_user/DeleteAppUserTest.kt
+++ b/reagent-order-kotlin-backend/reagent_order/src/test/kotlin/kkito/reagent_order/app_user/DeleteAppUserTest.kt
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.util.UUID
@@ -25,21 +24,22 @@ class DeleteAppUserTest(
         private val TABLE_NAMES = listOf("app_user")
     }
 
-    private lateinit var createdUserResponse: JSONObject
+    private lateinit var appUser: JSONObject
     private lateinit var jwtToken: String
 
     @BeforeEach
     override fun setUp() {
         super.setUp()
-        createdUserResponse = createResponseBodyJson(testDataAppUser.createAppUser())
-        jwtToken = testDataAppUser.login()
+        val createdUserResponse = createResponseBodyJson(testDataAppUser.createAppUser())
+        appUser = createdUserResponse.getJSONObject("appUserEntity")
+        jwtToken = createdUserResponse.getString("token")
     }
 
     @Test
     fun ユーザーを退会処理できる() {
         val changes = createChanges(TABLE_NAMES).setStartPointNow()
         val resultActions = mockMvc.perform(
-            delete("/app_user/${createdUserResponse.getString("id")}").header(
+            delete("/app_user/${appUser.getString("id")}").header(
                     "Authorization",
                     "Bearer $jwtToken"
                 )
@@ -54,9 +54,9 @@ class DeleteAppUserTest(
         Assertions.assertThat(changes).ofModificationOnTable("app_user").hasNumberOfChanges(1)
             .ofDeletionOnTable("app_user").hasNumberOfChanges(0).ofCreationOnTable("app_user")
             .hasNumberOfChanges(0).changeOfModification().rowAtEndPoint().value("id")
-            .isEqualTo(createdUserResponse.getString("id")).value("app_user_name")
-            .isEqualTo(createdUserResponse.getString("appUserName")).value("email")
-            .isEqualTo(createdUserResponse.getString("email"))
+            .isEqualTo(appUser.getString("id")).value("app_user_name")
+            .isEqualTo(appUser.getString("appUserName")).value("email")
+            .isEqualTo(appUser.getString("email"))
 //            .value("password").isEqualTo(createdUserResponse.getString("password"))
             .value("created_at").isNotNull().value("deleted_at").isNotNull()
     }
@@ -74,10 +74,10 @@ class DeleteAppUserTest(
 
     @Test
     fun 削除対象のユーザが削除済の場合() {
-        testDataAppUser.deleteAppUser(createdUserResponse.getString("id"), jwtToken)
+        testDataAppUser.deleteAppUser(appUser.getString("id"), jwtToken)
 
         val resultActions = mockMvc.perform(
-            delete("/app_user/${createdUserResponse.getString("id")}").header(
+            delete("/app_user/${appUser.getString("id")}").header(
                     "Authorization",
                     "Bearer $jwtToken"
                 )

--- a/reagent-order-kotlin-backend/reagent_order/src/test/kotlin/kkito/reagent_order/app_user/UpdateAppUserTest.kt
+++ b/reagent-order-kotlin-backend/reagent_order/src/test/kotlin/kkito/reagent_order/app_user/UpdateAppUserTest.kt
@@ -1,6 +1,5 @@
 package kkito.reagent_order.app_user
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import kkito.reagent_order.TestSupport
 import kkito.reagent_order.app_user.value.UpdateAppUserRequest
 import kkito.reagent_order.app_user.value.Role
@@ -18,7 +17,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
 import org.springframework.security.crypto.password.PasswordEncoder
-import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.util.UUID
@@ -35,14 +33,15 @@ class UpdateAppUserTest(
         private val TABLE_NAMES = listOf("app_user")
     }
 
-    private lateinit var createdUserResponse: JSONObject
+    private lateinit var appUser: JSONObject
     private lateinit var jwtToken: String
 
     @BeforeEach
     override fun setUp() {
         super.setUp()
-        createdUserResponse = createResponseBodyJson(testDataAppUser.createAppUser())
-        jwtToken = testDataAppUser.login()
+        val createdUserResponse = createResponseBodyJson(testDataAppUser.createAppUser())
+        appUser = createdUserResponse.getJSONObject("appUserEntity")
+        jwtToken = createdUserResponse.getString("token")
     }
 
     @ParameterizedTest
@@ -67,7 +66,7 @@ class UpdateAppUserTest(
 
         val changes = createChanges(TABLE_NAMES).setStartPointNow()
         val resultActions = mockMvc.perform(
-            put("/app_user/${createdUserResponse.getString("id")}")
+            put("/app_user/${appUser.getString("id")}")
                 .header("Authorization", "Bearer $jwtToken")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
@@ -105,15 +104,15 @@ class UpdateAppUserTest(
         val systemUserJwt = testDataAppUser.login(systemUser.email, systemUser.password)
 
         val request = UpdateAppUserRequest(
-            createdUserResponse.getString("appUserName"),
-            createdUserResponse.getString("email"),
+            appUser.getString("appUserName"),
+            appUser.getString("email"),
             "Test_pass_12345678",
             Role.ADMIN.value
         )
 
         val changes = createChanges(TABLE_NAMES).setStartPointNow()
         val resultActions = mockMvc.perform(
-            put("/app_user/${createdUserResponse.getString("id")}")
+            put("/app_user/${appUser.getString("id")}")
                 .header("Authorization", "Bearer $systemUserJwt")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
@@ -157,7 +156,7 @@ class UpdateAppUserTest(
 
         val changes = createChanges(TABLE_NAMES).setStartPointNow()
         val resultActions = mockMvc.perform(
-            put("/app_user/${createdUserResponse.getString("id")}")
+            put("/app_user/${appUser.getString("id")}")
                 .header("Authorization", "Bearer $jwtToken")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
@@ -189,7 +188,7 @@ class UpdateAppUserTest(
         )
 
         val resultActions = mockMvc.perform(
-            put("/app_user/${createdUserResponse.getString("id")}")
+            put("/app_user/${appUser.getString("id")}")
                 .header("Authorization", "Bearer $jwtToken")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
@@ -216,7 +215,7 @@ class UpdateAppUserTest(
         )
 
         val resultActions = mockMvc.perform(
-            put("/app_user/${createdUserResponse.getString("id")}")
+            put("/app_user/${appUser.getString("id")}")
                 .header("Authorization", "Bearer $jwtToken")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
@@ -256,7 +255,7 @@ class UpdateAppUserTest(
 
     @Test
     fun 退会済みのユーザーを更新しようとする場合_E0006エラーになる() {
-        testDataAppUser.deleteAppUser(createdUserResponse.getString("id"), jwtToken)
+        testDataAppUser.deleteAppUser(appUser.getString("id"), jwtToken)
 
         val request = UpdateAppUserRequest(
             "てすと 太郎",
@@ -266,7 +265,7 @@ class UpdateAppUserTest(
         )
 
         val resultActions = mockMvc.perform(
-            put("/app_user/${createdUserResponse.getString("id")}")
+            put("/app_user/${appUser.getString("id")}")
                 .header("Authorization", "Bearer $jwtToken")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
@@ -288,7 +287,7 @@ class UpdateAppUserTest(
         )
 
         val resultActions = mockMvc.perform(
-            put("/app_user/${createdUserResponse.getString("id")}")
+            put("/app_user/${appUser.getString("id")}")
                 .header("Authorization", "Bearer Invalid token")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
@@ -309,7 +308,7 @@ class UpdateAppUserTest(
         )
 
         val resultActions = mockMvc.perform(
-            put("/app_user/${createdUserResponse.getString("id")}")
+            put("/app_user/${appUser.getString("id")}")
                 .header("Authorization", "Bearer $jwtToken")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))

--- a/reagent-order-kotlin-backend/reagent_order/src/test/kotlin/kkito/reagent_order/login/LoginTest.kt
+++ b/reagent-order-kotlin-backend/reagent_order/src/test/kotlin/kkito/reagent_order/login/LoginTest.kt
@@ -44,7 +44,7 @@ class LoginTest(
         ).andExpect(status().isOk)
         val responseBody = createResponseBodyJson(resultActions)
         assertNotNull(
-            responseBody.getString("loginId")
+            responseBody.getString("token")
         )
         val loginUser = responseBody.getJSONObject("appUserEntity")
         assertNotNull(loginUser.getString("id"))

--- a/reagent-order-kotlin-backend/reagent_order/src/test/kotlin/kkito/reagent_order/login/LoginTest.kt
+++ b/reagent-order-kotlin-backend/reagent_order/src/test/kotlin/kkito/reagent_order/login/LoginTest.kt
@@ -1,6 +1,5 @@
 package kkito.reagent_order.login
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import kkito.reagent_order.TestSupport
 import kkito.reagent_order.app_user.value.Role
 import kkito.reagent_order.error.ErrorCode
@@ -11,7 +10,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
-import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import kotlin.test.assertEquals
@@ -32,7 +30,7 @@ class LoginTest(
 
     @Test
     fun ログインできる() {
-        val resisterUser = createResponseBodyJson(testDataAppUser.createAppUser())
+        val resisterUser = createResponseBodyJson(testDataAppUser.createAppUser()).getJSONObject("appUserEntity")
         val request = LoginRequest(
             resisterUser.getString("email"),
             "Test_pass_12345678"
@@ -56,7 +54,7 @@ class LoginTest(
 
     @Test
     fun パスワードが間違っている場合_ログインできない_E0008エラーになる() {
-        val resisterUser = createResponseBodyJson(testDataAppUser.createAppUser())
+        val resisterUser = createResponseBodyJson(testDataAppUser.createAppUser()).getJSONObject("appUserEntity")
         val request = LoginRequest(
             resisterUser.getString("email"),
             "Bad_Password"

--- a/reagent-order-kotlin-backend/reagent_order/src/test/kotlin/kkito/reagent_order/order/CreateOrderTest.kt
+++ b/reagent-order-kotlin-backend/reagent_order/src/test/kotlin/kkito/reagent_order/order/CreateOrderTest.kt
@@ -1,6 +1,5 @@
 package kkito.reagent_order.order
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import kkito.reagent_order.TestSupport
 import kkito.reagent_order.error.ErrorCode
 import kkito.reagent_order.order.value.OrderDetailRequest
@@ -14,7 +13,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
-import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -29,14 +27,15 @@ class CreateOrderTest(
         private val TABLE_NAMES = listOf("app_user", "user_order", "order_detail", "order_set")
     }
 
-    private lateinit var createdUserResponse: JSONObject
+    private lateinit var appUser: JSONObject
     private lateinit var jwtToken: String
 
     @BeforeEach
     override fun setUp() {
         super.setUp()
-        createdUserResponse = createResponseBodyJson(testDataAppUser.createAppUser())
-        jwtToken = testDataAppUser.login()
+        val createdUserResponse = createResponseBodyJson(testDataAppUser.createAppUser())
+        appUser = createdUserResponse.getJSONObject("appUserEntity")
+        jwtToken = createdUserResponse.getString("token")
     }
 
     @Test
@@ -98,7 +97,7 @@ class CreateOrderTest(
             .isCreation()
             .rowAtEndPoint()
             .value("id").isNotNull()
-            .value("app_user_id").isEqualTo(createdUserResponse.getString("id"))
+            .value("app_user_id").isEqualTo(appUser.getString("id"))
             .value("title").isEqualTo(request.title)
             .value("created_at").isNotNull()
             .value("deleted_at").isNull()
@@ -217,7 +216,7 @@ class CreateOrderTest(
             .isCreation()
             .rowAtEndPoint()
             .value("id").isNotNull()
-            .value("app_user_id").isEqualTo(createdUserResponse.getString("id"))
+            .value("app_user_id").isEqualTo(appUser.getString("id"))
             .value("title").isEqualTo(request.title)
             .value("created_at").isNotNull()
             .value("deleted_at").isNull()

--- a/reagent-order-kotlin-backend/reagent_order/src/test/kotlin/kkito/reagent_order/order/DeleteOrderTest.kt
+++ b/reagent-order-kotlin-backend/reagent_order/src/test/kotlin/kkito/reagent_order/order/DeleteOrderTest.kt
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
-import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 

--- a/reagent-order-kotlin-backend/reagent_order/src/test/kotlin/kkito/reagent_order/order/GetOrderTest.kt
+++ b/reagent-order-kotlin-backend/reagent_order/src/test/kotlin/kkito/reagent_order/order/GetOrderTest.kt
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
-import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.util.stream.IntStream
@@ -23,29 +22,28 @@ class GetOrderTest(
     @Autowired private val testDataAppUser: TestDataAppUser,
     @Autowired private val testDataOrder: TestDataOrder,
 ) : TestSupport() {
-    private lateinit var createdUserResponse: JSONObject
+    private lateinit var appUser: JSONObject
     private lateinit var jwtToken: String
 
-    private lateinit var otherCreateUserResponse: JSONObject
+    private lateinit var otherUser: JSONObject
     private lateinit var otherJwtToken: String
 
     @BeforeEach
     override fun setUp() {
         super.setUp()
-        createdUserResponse = createResponseBodyJson(testDataAppUser.createAppUser())
-        jwtToken = testDataAppUser.login()
+        val createdUserResponse = createResponseBodyJson(testDataAppUser.createAppUser())
+        appUser = createdUserResponse.getJSONObject("appUserEntity")
+        jwtToken = createdUserResponse.getString("token")
 
-        otherCreateUserResponse = createResponseBodyJson(
+        val otherCreateUserResponse = createResponseBodyJson(
             testDataAppUser.createAppUser(
                 appUserName = "サブユーザー",
                 email = "sum_mail@test.gmail.com",
                 password = "SubPassword123"
             )
         )
-        otherJwtToken = testDataAppUser.login(
-            email = "sum_mail@test.gmail.com",
-            password = "SubPassword123"
-        )
+        otherUser = otherCreateUserResponse.getJSONObject("appUserEntity")
+        otherJwtToken = otherCreateUserResponse.getString("token")
     }
 
     @Test
@@ -90,8 +88,8 @@ class GetOrderTest(
         testDataOrder.createOrder(requestOrders[0], jwtToken)
         testDataOrder.createOrder(requestOrders[1], otherJwtToken)
         val userNames = listOf(
-            createdUserResponse.getString("appUserName"),
-            otherCreateUserResponse.getString("appUserName")
+            appUser.getString("appUserName"),
+            otherUser.getString("appUserName")
         )
         val resultActions = mockMvc.perform(
             get("/order").contentType(MediaType.APPLICATION_JSON)

--- a/reagent-order-kotlin-backend/reagent_order/src/test/kotlin/kkito/reagent_order/test_data/TestDataAppUser.kt
+++ b/reagent-order-kotlin-backend/reagent_order/src/test/kotlin/kkito/reagent_order/test_data/TestDataAppUser.kt
@@ -57,7 +57,7 @@ class TestDataAppUser {
                 .content(objectMapper.writeValueAsString(request))
         ).andExpect(MockMvcResultMatchers.status().isOk)
         val responseBody = createResponseBodyJson(resultActions)
-        return responseBody.getString("loginId")
+        return responseBody.getString("token")
     }
 
     private fun createResponseBodyJson(resultAction: ResultActions): JSONObject {


### PR DESCRIPTION
- [アプリユーザー作成時にログイントークンも発行するようにした](https://github.com/kkito0726/reagent-order/commit/c2387244046b697fdff6f5b683a9cc10eb8177ff)
- [LoginResponseのフィールド名を変更](https://github.com/kkito0726/reagent-order/commit/8f75fcc2c52c29662d509ebb5d2263272a78208e)